### PR TITLE
DetailsView: Optionally look for screenshot, marquee

### DIFF
--- a/DetailsView.qml
+++ b/DetailsView.qml
@@ -124,7 +124,10 @@ FocusScope {
 
                 anchors.fill: parent
                 asynchronous: true
-                source: currentGame.assets.boxFront || currentGame.assets.logo
+                source: currentGame.assets.boxFront ||
+                        currentGame.assets.logo ||
+                        currentGame.assets.screenshot ||
+                        currentGame.assets.marquee
                 sourceSize { width: 256; height: 256 } // optimization (max size)
                 fillMode: Image.PreserveAspectFit
                 horizontalAlignment: Image.AlignLeft


### PR DESCRIPTION
I use Skyscraper which generally adds assets such as `screenshot` and `marquee`.

I've updated the theme to look for those assets if `boxFront` and `logo` aren't found.